### PR TITLE
Changes to get Destalinator working again, for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # Where to store your personal API token
 *_token.txt
+
+# Any virtual environment
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM python:2.7
-WORKDIR /destalinator
-ADD bin/install bin/
-ADD build-requirements.txt .
-ADD requirements.txt .
-RUN ./bin/install
-ADD *.py ./
-ADD *.txt ./
-ADD *.md ./
-ADD Procfile .
-ADD LICENSE .
-ADD configuration.yaml .
-ADD utils/*.py utils/
-ADD tests/* tests/
-ADD bin/test bin/
-RUN ./bin/test
+FROM python:3.7-buster
+
 ENV DESTALINATOR_LOG_LEVEL WARNING
-CMD python scheduler.py
+
+WORKDIR /destalinator
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+CMD ["python3", "scheduler.py"]

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,6 +1,3 @@
-# Name of your Slack (Deprecated in favour of the slack_name env var)
-slack_name: rands-leadership
-
 # Name of environment variable that determines if destalinator should
 # actually do things to a live slack. Without this environment variable,
 # everything will output in a "dry run" fashion (debug messages should take place,

--- a/destalinator.py
+++ b/destalinator.py
@@ -158,7 +158,7 @@ class Destalinator(WithLogger, WithConfig):
                 self.logger.info("Archived %s", channel_name)
             else:
                 error = payload.get('error', '!! No error found in payload %s !!' % payload)
-                self.logger.error("Failed to archive %s: %s. See https://api.slack.com/methods/channels.archive for more context.", channel_name, error)
+                self.logger.error("Failed to archive %s: %s. See https://api.slack.com/methods/conversations.archive for more context.", channel_name, error)
 
             return payload
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-APScheduler>=3.0.5
+APScheduler==3.0.5
 requests>=2.20.0
 PyYAML>=3.11
-raven>=6.1.0
+raven==6.1.0


### PR DESCRIPTION
Updated several code sections to use Slack's latest API semantics, as well as bumping some things to Python 3.7 vs 2.7. I tested in my own Slack Workspace, and it behaves as expected -- though, warnings won't post if the channel is staler than 60 days; it just goes straight to archive. I believe this is the intended behavior, since I didn't change anything to make it do that.

(Hot tip for testing: you can force a run by setting an env var and then running the command as usual: `DESTALINATOR_RUN_ONCE=True python3 scheduler.py`)

Two major issues still: one to work on in the codebase, and one to call out as a huge PITA.

1. I fixed the module-level errors by pinning versions. One package, `APScheduler`, feels dirty to use, and I'd rather rely on host `cron`, honestly. The other package, `raven`, is some weird deprecated DNS tester, or... something? I don't like it, and I want to take it out.

1. The other issue seems to be that new-world-order OAuth Slack Apps are _*not*_ in all channels automatically; you have to explicitly, manually add them to each channel. I am having zero luck finding out how to just have them join all channels automatically, but will keep looking.