### PR TITLE
Add join_channel method

### DIFF
--- a/slacker.py
+++ b/slacker.py
@@ -93,7 +93,7 @@ class Slacker(WithLogger, WithConfig):
                 self.join_channel(cid)
                 payload = self.get_with_retry_to_json(murl)
                 if not payload['ok']:
-                    raise Exception("Unable to auto-join channel; are the apps's OAuth scopes set correctly?")
+                    raise Exception(f"Unable to auto-join channel {cname}; are the app's OAuth scopes set correctly?")
             messages += payload['messages']
             if payload['has_more'] is False:
                 done = True

--- a/slacker.py
+++ b/slacker.py
@@ -92,6 +92,8 @@ class Slacker(WithLogger, WithConfig):
                 print(f'Auto-joining channel {cname}')
                 self.join_channel(cid)
                 payload = self.get_with_retry_to_json(murl)
+                if not payload['ok']:
+                    raise Exception("Unable to auto-join channel; are the apps's OAuth scopes set correctly?")
             messages += payload['messages']
             if payload['has_more'] is False:
                 done = True

--- a/slacker.py
+++ b/slacker.py
@@ -235,7 +235,7 @@ class Slacker(WithLogger, WithConfig):
         if exclude_archived (default: True), only shows non-archived channels
         """
 
-        url_template = self.url + "conversations.list?exclude_archived={}&token={}"
+        url_template = self.url + "conversations.list?exclude_archived={}&token={}&limit=1000"
         if exclude_archived:
             exclude_archived = 1
         else:

--- a/slacker.py
+++ b/slacker.py
@@ -223,7 +223,26 @@ class Slacker(WithLogger, WithConfig):
         url = url_template.format(exclude_archived, self.token)
         payload = self.get_with_retry_to_json(url)
         assert 'channels' in payload
+        # Hotfix for newer Slack apps
+        self.join_channels(payload['channels'])
         return payload['channels']
+    
+    def join_channels(self, channels):
+        """
+        Fix for new-type Slack apps where apps need to already be in channels to
+        work. This sucks right now, because it will try to re-join ALL channels
+        until I get a heuristic fix in
+        """
+        print('Trying to join channels not currently a member of')
+        for channel in channels:
+            url_template = self.url + "conversations.join?channel={}&token={}"
+            url = url_template.format(channel['id'], self.token)
+            try:
+                res = requests.post(url)
+            except Exception:
+                time.sleep(3)
+                res = requests.post(url)
+            assert res.status_code == 200
 
     def get_all_user_objects(self):
         url = self.url + "users.list?token=" + self.token


### PR DESCRIPTION
This took some fuddling, since apparently `destalinator` is a concurrent program and I had to figure out where best to put it. This adds a `join_channel` method that slots in right after the failure point when it tries to read messages from a channel the app isn't a member of, because of the newer OAuth permissions for Slack Apps. If it has an empty history body, it'll join the channel and then re-read the history.

This requires that the app have `channels:join` permissions, obviously, and right now it's failing in our workspace because of that. But I've confirmed the functionality in my own workspace.